### PR TITLE
Allow !joinrole to join multiple roles

### DIFF
--- a/rolesmodule/RolesModule.go
+++ b/rolesmodule/RolesModule.go
@@ -212,11 +212,12 @@ func (c *joinRoleCommand) Process(args []string, msg *discordgo.Message, indices
 	}
 	var roles []*discordgo.Role
 	// Initially attempt to get the entire message as a role, for backwards compatibility.
-	r, err := GetUserAssignableRole(msg.Content[indices[0]:], info)
+	content := msg.Content[indices[0]:]
+	r, err := GetUserAssignableRole(content, info)
 	if err != nil {
 		// Try to pull individual roles instead.
-		for _, arg := range args {
-			r, err := GetUserAssignableRole(arg, info)
+		for _, arg := range strings.Split(content, ",") {
+			r, err := GetUserAssignableRole(strings.TrimSpace(arg), info)
 			if err != nil {
 				return bot.ReturnError(err)
 			}
@@ -239,10 +240,10 @@ func (c *joinRoleCommand) joinSingleRole(info *bot.GuildInfo, msg *discordgo.Mes
 	hasrole := info.UserHasRole(bot.DiscordUser(msg.Author.ID), bot.DiscordRole(r.ID))
 	err := info.ResolveRoleAddError(info.Bot.DG.GuildMemberRoleAdd(info.ID, msg.Author.ID, r.ID)) // Try adding the role no matter what, just in case discord screwed up
 	if hasrole {
-		return "```\nYou already have that role.```"
+		return "```You already have that role.```"
 	}
 	if err != nil {
-		return "```\nError adding role! " + err.Error() + "```"
+		return "```Error adding role! " + err.Error() + "```"
 	}
 	pingable := ""
 	if r.Mentionable {

--- a/sweetiebot/sweetiebot.go
+++ b/sweetiebot/sweetiebot.go
@@ -36,7 +36,7 @@ var guildfileregex = regexp.MustCompile("^([0-9]+)[.]json$")
 const DiscordEpoch uint64 = 1420070400000
 
 // BotVersion stores the current version of sweetiebot
-var BotVersion = Version{1, 0, 1, 9}
+var BotVersion = Version{1, 0, 2, 0}
 
 const (
 	MaxPublicLines    = 12
@@ -1069,6 +1069,7 @@ func New(token string, loader func(*GuildInfo) []Module) *SweetieBot {
 		WebDomain:      "localhost",
 		WebPort:        ":80",
 		changelog: map[int]string{
+			AssembleVersion(1, 0, 2, 0):  "- Added the ability for !joinrole to do multiple roles, e.g. !joinrole A, B\n- Update discordgo",
 			AssembleVersion(1, 0, 1, 9):  "- Introduced the !decrement command. This will decrement a counter by 1.",
 			AssembleVersion(1, 0, 1, 8):  "- Actually fix new user detection by requesting the necessary privileged intent\n- Fixed quote mention problems caused by discordgo deleting the entire member list on reconnecting.",
 			AssembleVersion(1, 0, 1, 7):  "- Attempt to fix new user detection problems",


### PR DESCRIPTION
Current syntax: `A, B, C` / `A,B,C`.

`!joinrole A, B` will first try to join the role `A, B` for backwards compatibility, and if that fails it will try `A` and `B` instead.